### PR TITLE
Use generics in cache

### DIFF
--- a/fstxn/fsstate.go
+++ b/fstxn/fsstate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mit-pdos/go-journal/lockmap"
 	"github.com/mit-pdos/go-journal/obj"
 	"github.com/mit-pdos/go-nfsd/cache"
+	"github.com/mit-pdos/go-nfsd/inode"
 	"github.com/mit-pdos/go-nfsd/super"
 )
 
@@ -14,7 +15,7 @@ const ICACHESZ uint64 = 100
 type FsState struct {
 	Super   *super.FsSuper
 	Txn     *obj.Log
-	Icache  *cache.Cache
+	Icache  *cache.Cache[*inode.Inode]
 	Lockmap *lockmap.LockMap
 	Balloc  *alloc.Alloc
 	Ialloc  *alloc.Alloc
@@ -34,7 +35,7 @@ func MkFsState(super *super.FsSuper, log *obj.Log) *FsState {
 		super.NBlockBitmap))
 	ialloc := alloc.MkAlloc(readBitmap(super, super.BitmapInodeStart(),
 		super.NInodeBitmap))
-	icache := cache.MkCache(ICACHESZ)
+	icache := cache.MkCache[*inode.Inode](ICACHESZ)
 	st := &FsState{
 		Super:   super,
 		Txn:     log,

--- a/fstxn/fstxn.go
+++ b/fstxn/fstxn.go
@@ -78,7 +78,7 @@ func (op *FsTxn) ReleaseInode(ip *inode.Inode) {
 	op.Fs.Lockmap.Release(ip.Inum)
 }
 
-func (op *FsTxn) LockInode(inum common.Inum) *cache.Cslot {
+func (op *FsTxn) LockInode(inum common.Inum) *cache.Cslot[*inode.Inode] {
 	op.Fs.Lockmap.Acquire(inum)
 	cslot := op.Fs.Icache.LookupSlot(uint64(inum))
 	if cslot == nil {
@@ -96,7 +96,7 @@ func (op *FsTxn) GetInodeLocked(inum common.Inum) *inode.Inode {
 		util.DPrintf(1, "GetInodeLocked # %v: read inode from disk\n", inum)
 		cslot.Obj = i
 	}
-	ip := cslot.Obj.(*inode.Inode)
+	ip := cslot.Obj
 	op.addInode(ip)
 	util.DPrintf(1, "%p: GetInodeLocked %v\n", op.Atxn.Id(), ip)
 	return ip


### PR DESCRIPTION
## Summary
- make cache structures generic
- update fsstate and fstxn to use generic cache
- run gofmt
- run go vet, go test, and go build (all failed due to missing network)

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: no route to host)*
- `go test ./...` *(fails: proxyconnect tcp: no route to host)*
- `go build ./...` *(fails: proxyconnect tcp: no route to host)*