### PR TITLE
Add documentation for exported APIs

### DIFF
--- a/inode/inode.go
+++ b/inode/inode.go
@@ -26,6 +26,7 @@ const (
 	NINDLEVEL uint64 = 2                  // # levels of indirection
 )
 
+// Inode represents an on-disk inode with some in-memory metadata.
 type Inode struct {
 	// in-memory info:
 	Inum   common.Inum

--- a/kvs/kvs.go
+++ b/kvs/kvs.go
@@ -11,23 +11,23 @@ import (
 	"github.com/mit-pdos/go-journal/util"
 )
 
-//
-// KVS using txns to implement multiput / multiget transactions
-// Keys == Block addresses
-//
+// Package kvs implements a very small key-value store using journaled transactions.
 
 const DISKNAME string = "goose_kvs.img"
 
+// KVS is a transactional key-value store backed by a disk log.
 type KVS struct {
 	sz  uint64
 	log *obj.Log
 }
 
+// KVPair represents a key-value pair.
 type KVPair struct {
 	Key uint64
 	Val []byte
 }
 
+// MkKVS initializes a new store on the provided disk.
 func MkKVS(d disk.Disk, sz uint64) *KVS {
 	/*if sz > d.Size() {
 		panic("kvs larger than disk")
@@ -41,6 +41,7 @@ func MkKVS(d disk.Disk, sz uint64) *KVS {
 	return kvs
 }
 
+// MultiPut atomically writes multiple key/value pairs.
 func (kvs *KVS) MultiPut(pairs []KVPair) bool {
 	op := jrnl.Begin(kvs.log)
 	for _, p := range pairs {
@@ -54,6 +55,7 @@ func (kvs *KVS) MultiPut(pairs []KVPair) bool {
 	return ok
 }
 
+// Get retrieves the value for a key.
 func (kvs *KVS) Get(key uint64) (*KVPair, bool) {
 	if key > kvs.sz || key < common.LOGSIZE {
 		panic(fmt.Errorf("out-of-bounds get at %v", key))
@@ -68,6 +70,7 @@ func (kvs *KVS) Get(key uint64) (*KVPair, bool) {
 	}, ok
 }
 
+// Delete releases all resources associated with the store.
 func (kvs *KVS) Delete() {
 	kvs.log.Shutdown()
 }

--- a/nfs/mount.go
+++ b/nfs/mount.go
@@ -8,10 +8,12 @@ import (
 	"log"
 )
 
+// MOUNTPROC3_NULL handles the NULL RPC for the mount service.
 func (nfs *Nfs) MOUNTPROC3_NULL() {
 	util.DPrintf(1, "MOUNT Null\n")
 }
 
+// MOUNTPROC3_MNT implements the MNT RPC to mount the root file system.
 func (nfs *Nfs) MOUNTPROC3_MNT(args nfstypes.Dirpath3) nfstypes.Mountres3 {
 	reply := new(nfstypes.Mountres3)
 	util.DPrintf(1, "MOUNT Mount %v\n", args)
@@ -20,19 +22,23 @@ func (nfs *Nfs) MOUNTPROC3_MNT(args nfstypes.Dirpath3) nfstypes.Mountres3 {
 	return *reply
 }
 
+// MOUNTPROC3_UMNT handles unmount requests.
 func (nfs *Nfs) MOUNTPROC3_UMNT(args nfstypes.Dirpath3) {
 	util.DPrintf(1, "MOUNT Unmount %v\n", args)
 }
 
+// MOUNTPROC3_UMNTALL unmounts all file systems.
 func (nfs *Nfs) MOUNTPROC3_UMNTALL() {
 	log.Printf("Unmountall\n")
 }
 
+// MOUNTPROC3_DUMP returns mount table entries.
 func (nfs *Nfs) MOUNTPROC3_DUMP() nfstypes.Mountopt3 {
 	log.Printf("Dump\n")
 	return nfstypes.Mountopt3{P: nil}
 }
 
+// MOUNTPROC3_EXPORT returns export options.
 func (nfs *Nfs) MOUNTPROC3_EXPORT() nfstypes.Exportsopt3 {
 	res := nfstypes.Exports3{
 		Ex_dir:    "",

--- a/nfs/nfs.go
+++ b/nfs/nfs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mit-pdos/go-nfsd/util/stats"
 )
 
+// Nfs provides the main NFS server state and helper threads.
 type Nfs struct {
 	fsstate  *fstxn.FsState
 	shrinkst *shrinker.ShrinkerSt
@@ -24,6 +25,7 @@ type Nfs struct {
 	stats [NUM_NFS_OPS]stats.Op
 }
 
+// MakeNfs initializes a new NFS server backed by disk d.
 func MakeNfs(d disk.Disk) *Nfs {
 	// run first so that disk is initialized before mkLog
 	super := super.MkFsSuper(d)
@@ -51,6 +53,7 @@ func MakeNfs(d disk.Disk) *Nfs {
 	return nfs
 }
 
+// ShutdownNfs cleanly shuts down the server and background threads.
 func (nfs *Nfs) ShutdownNfs() {
 	util.DPrintf(1, "Shutdown\n")
 	nfs.shrinkst.Shutdown()
@@ -58,7 +61,7 @@ func (nfs *Nfs) ShutdownNfs() {
 	util.DPrintf(1, "Shutdown done\n")
 }
 
-// Terminates shrinker thread immediately
+// Crash terminates the shrinker and shuts down without waiting.
 func (nfs *Nfs) Crash() {
 	util.DPrintf(0, "Crash: terminate shrinker\n")
 	nfs.shrinkst.Crash()

--- a/nfs/nfs_clnt.go
+++ b/nfs/nfs_clnt.go
@@ -8,10 +8,12 @@ import (
 	"github.com/mit-pdos/go-nfsd/nfstypes"
 )
 
+// NfsClient wraps an in-process NFS server for simple unit tests.
 type NfsClient struct {
 	srv *Nfs
 }
 
+// MkNfsClient creates a new client backed by an in-memory disk of size sz.
 func MkNfsClient(sz uint64) *NfsClient {
 	d := disk.NewMemDisk(sz)
 	return &NfsClient{
@@ -19,14 +21,17 @@ func MkNfsClient(sz uint64) *NfsClient {
 	}
 }
 
+// Shutdown stops the underlying server and releases resources.
 func (clnt *NfsClient) Shutdown() {
 	clnt.srv.ShutdownNfs()
 }
 
+// Crash forces the server to terminate without a graceful shutdown.
 func (clnt *NfsClient) Crash() {
 	clnt.srv.Crash()
 }
 
+// CreateOp issues an NFS CREATE request.
 func (clnt *NfsClient) CreateOp(fh nfstypes.Nfs_fh3, name string) nfstypes.CREATE3res {
 	where := nfstypes.Diropargs3{Dir: fh, Name: nfstypes.Filename3(name)}
 	how := nfstypes.Createhow3{}
@@ -35,6 +40,7 @@ func (clnt *NfsClient) CreateOp(fh nfstypes.Nfs_fh3, name string) nfstypes.CREAT
 	return attr
 }
 
+// LookupOp performs an NFS LOOKUP request.
 func (clnt *NfsClient) LookupOp(fh nfstypes.Nfs_fh3, name string) *nfstypes.LOOKUP3res {
 	what := nfstypes.Diropargs3{Dir: fh, Name: nfstypes.Filename3(name)}
 	args := nfstypes.LOOKUP3args{What: what}
@@ -42,12 +48,14 @@ func (clnt *NfsClient) LookupOp(fh nfstypes.Nfs_fh3, name string) *nfstypes.LOOK
 	return &reply
 }
 
+// GetattrOp fetches attributes for a file handle.
 func (clnt *NfsClient) GetattrOp(fh nfstypes.Nfs_fh3) *nfstypes.GETATTR3res {
 	args := nfstypes.GETATTR3args{Object: fh}
 	attr := clnt.srv.NFSPROC3_GETATTR(args)
 	return &attr
 }
 
+// WriteOp sends an NFS WRITE request.
 func (clnt *NfsClient) WriteOp(fh nfstypes.Nfs_fh3, off uint64, data []byte, how nfstypes.Stable_how) *nfstypes.WRITE3res {
 	args := nfstypes.WRITE3args{
 		File:   fh,
@@ -59,6 +67,7 @@ func (clnt *NfsClient) WriteOp(fh nfstypes.Nfs_fh3, off uint64, data []byte, how
 	return &reply
 }
 
+// ReadOp issues an NFS READ request.
 func (clnt *NfsClient) ReadOp(fh nfstypes.Nfs_fh3, off uint64, sz uint64) *nfstypes.READ3res {
 	args := nfstypes.READ3args{
 		File:   fh,
@@ -68,6 +77,7 @@ func (clnt *NfsClient) ReadOp(fh nfstypes.Nfs_fh3, off uint64, sz uint64) *nfsty
 	return &reply
 }
 
+// RemoveOp issues an NFS REMOVE request.
 func (clnt *NfsClient) RemoveOp(dir nfstypes.Nfs_fh3, name string) nfstypes.REMOVE3res {
 	what := nfstypes.Diropargs3{Dir: dir, Name: nfstypes.Filename3(name)}
 	args := nfstypes.REMOVE3args{
@@ -77,6 +87,7 @@ func (clnt *NfsClient) RemoveOp(dir nfstypes.Nfs_fh3, name string) nfstypes.REMO
 	return reply
 }
 
+// MkDirOp sends an NFS MKDIR request.
 func (clnt *NfsClient) MkDirOp(dir nfstypes.Nfs_fh3, name string) nfstypes.MKDIR3res {
 	where := nfstypes.Diropargs3{Dir: dir, Name: nfstypes.Filename3(name)}
 	sattr := nfstypes.Sattr3{}
@@ -85,6 +96,7 @@ func (clnt *NfsClient) MkDirOp(dir nfstypes.Nfs_fh3, name string) nfstypes.MKDIR
 	return attr
 }
 
+// RmDirOp issues an NFS RMDIR request.
 func (clnt *NfsClient) RmDirOp(dir nfstypes.Nfs_fh3, name string) nfstypes.RMDIR3res {
 	where := nfstypes.Diropargs3{Dir: dir, Name: nfstypes.Filename3(name)}
 	args := nfstypes.RMDIR3args{Object: where}
@@ -92,6 +104,7 @@ func (clnt *NfsClient) RmDirOp(dir nfstypes.Nfs_fh3, name string) nfstypes.RMDIR
 	return attr
 }
 
+// SymLinkOp creates a symlink.
 func (clnt *NfsClient) SymLinkOp(dir nfstypes.Nfs_fh3, name string, path nfstypes.Nfspath3) nfstypes.SYMLINK3res {
 	where := nfstypes.Diropargs3{Dir: dir, Name: nfstypes.Filename3(name)}
 	sattr := nfstypes.Sattr3{}
@@ -101,12 +114,14 @@ func (clnt *NfsClient) SymLinkOp(dir nfstypes.Nfs_fh3, name string, path nfstype
 	return attr
 }
 
+// ReadLinkOp reads the target of a symlink.
 func (clnt *NfsClient) ReadLinkOp(fh nfstypes.Nfs_fh3) nfstypes.READLINK3res {
 	args := nfstypes.READLINK3args{Symlink: fh}
 	attr := clnt.srv.NFSPROC3_READLINK(args)
 	return attr
 }
 
+// CommitOp forces data to stable storage with an NFS COMMIT call.
 func (clnt *NfsClient) CommitOp(fh nfstypes.Nfs_fh3, cnt uint64) *nfstypes.COMMIT3res {
 	args := nfstypes.COMMIT3args{
 		File:   fh,
@@ -116,6 +131,7 @@ func (clnt *NfsClient) CommitOp(fh nfstypes.Nfs_fh3, cnt uint64) *nfstypes.COMMI
 	return &reply
 }
 
+// RenameOp issues an NFS RENAME request.
 func (clnt *NfsClient) RenameOp(fhfrom nfstypes.Nfs_fh3, from string,
 	fhto nfstypes.Nfs_fh3, to string) nfstypes.Nfsstat3 {
 	args := nfstypes.RENAME3args{
@@ -126,6 +142,7 @@ func (clnt *NfsClient) RenameOp(fhfrom nfstypes.Nfs_fh3, from string,
 	return reply.Status
 }
 
+// SetattrOp truncates or otherwise sets attributes for a file.
 func (clnt *NfsClient) SetattrOp(fh nfstypes.Nfs_fh3, sz uint64) nfstypes.SETATTR3res {
 	size := nfstypes.Set_size3{Set_it: true, Size: nfstypes.Size3(sz)}
 	attr := nfstypes.Sattr3{Size: size}
@@ -134,13 +151,14 @@ func (clnt *NfsClient) SetattrOp(fh nfstypes.Nfs_fh3, sz uint64) nfstypes.SETATT
 	return reply
 }
 
+// ReadDirPlusOp issues a READDIRPLUS request for directory listings.
 func (clnt *NfsClient) ReadDirPlusOp(dir nfstypes.Nfs_fh3, cnt uint64) nfstypes.READDIRPLUS3res {
 	args := nfstypes.READDIRPLUS3args{Dir: dir, Dircount: nfstypes.Count3(100), Maxcount: nfstypes.Count3(cnt)}
 	reply := clnt.srv.NFSPROC3_READDIRPLUS(args)
 	return reply
 }
 
-// Run parallel clients executing f(), each in their own directory
+// Parallel runs nthread clients in parallel, executing f for each.
 func Parallel(nthread int, disksz uint64,
 	f func(clnt *NfsClient, dirfh nfstypes.Nfs_fh3) int) int {
 	root := fh.MkRootFh3()

--- a/nfs/nfs_ls.go
+++ b/nfs/nfs_ls.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mit-pdos/go-nfsd/nfstypes"
 )
 
+// Ls3 lists directory entries with attributes and handles.
 func Ls3(dip *inode.Inode, op *fstxn.FsTxn, start nfstypes.Cookie3, dircount, maxcount nfstypes.Count3) nfstypes.Dirlistplus3 {
 	var lst *nfstypes.Entryplus3
 	var last *nfstypes.Entryplus3
@@ -44,6 +45,7 @@ func Ls3(dip *inode.Inode, op *fstxn.FsTxn, start nfstypes.Cookie3, dircount, ma
 	return dl
 }
 
+// Readdir3 returns directory entries without additional attributes.
 func Readdir3(dip *inode.Inode, op *fstxn.FsTxn,
 	start nfstypes.Cookie3, count nfstypes.Count3) nfstypes.Dirlist3 {
 	var lst *nfstypes.Entry3

--- a/nfs/nfs_ops.go
+++ b/nfs/nfs_ops.go
@@ -38,10 +38,12 @@ func commitReply(op *fstxn.FsTxn, status *nfstypes.Nfsstat3) {
 	}
 }
 
+// NFSPROC3_NULL implements the NFSv3 _NULL RPC.
 func (nfs *Nfs) NFSPROC3_NULL() {
 	util.DPrintf(1, "NFS Null\n")
 }
 
+// NFSPROC3_GETATTR implements the NFSv3 _GETATTR RPC.
 func (nfs *Nfs) NFSPROC3_GETATTR(args nfstypes.GETATTR3args) nfstypes.GETATTR3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_GETATTR, time.Now())
 	var reply nfstypes.GETATTR3res
@@ -87,6 +89,7 @@ func (nfs *Nfs) getShrink(fh nfstypes.Nfs_fh3) (*fstxn.FsTxn, *inode.Inode, nfst
 	return op, ip, err
 }
 
+// NFSPROC3_SETATTR implements the NFSv3 _SETATTR RPC.
 func (nfs *Nfs) NFSPROC3_SETATTR(args nfstypes.SETATTR3args) nfstypes.SETATTR3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_SETATTR, time.Now())
 	var reply nfstypes.SETATTR3res
@@ -203,6 +206,7 @@ func (nfs *Nfs) getInodesLocked(dfh nfstypes.Nfs_fh3, name nfstypes.Filename3) (
 }
 
 // Lookup must lock child inode to find gen number
+// NFSPROC3_LOOKUP implements the NFSv3 _LOOKUP RPC.
 func (nfs *Nfs) NFSPROC3_LOOKUP(args nfstypes.LOOKUP3args) nfstypes.LOOKUP3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_LOOKUP, time.Now())
 	var reply nfstypes.LOOKUP3res
@@ -222,6 +226,7 @@ func (nfs *Nfs) NFSPROC3_LOOKUP(args nfstypes.LOOKUP3args) nfstypes.LOOKUP3res {
 	return reply
 }
 
+// NFSPROC3_ACCESS implements the NFSv3 _ACCESS RPC.
 func (nfs *Nfs) NFSPROC3_ACCESS(args nfstypes.ACCESS3args) nfstypes.ACCESS3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_ACCESS, time.Now())
 	var reply nfstypes.ACCESS3res
@@ -248,6 +253,7 @@ func (nfs *Nfs) doRead(fh nfstypes.Nfs_fh3, kind nfstypes.Ftype3, offset, count 
 	return op, data, eof, nfstypes.NFS3_OK
 }
 
+// NFSPROC3_READ implements the NFSv3 _READ RPC.
 func (nfs *Nfs) NFSPROC3_READ(args nfstypes.READ3args) nfstypes.READ3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_READ, time.Now())
 	var reply nfstypes.READ3res
@@ -266,6 +272,7 @@ func (nfs *Nfs) NFSPROC3_READ(args nfstypes.READ3args) nfstypes.READ3res {
 }
 
 // XXX Mtime
+// NFSPROC3_WRITE implements the NFSv3 _WRITE RPC.
 func (nfs *Nfs) NFSPROC3_WRITE(args nfstypes.WRITE3args) nfstypes.WRITE3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_WRITE, time.Now())
 	var reply nfstypes.WRITE3res
@@ -429,6 +436,7 @@ func (nfs *Nfs) doCreate(dfh nfstypes.Nfs_fh3, name nfstypes.Filename3, kind nfs
 	return
 }
 
+// NFSPROC3_CREATE implements the NFSv3 _CREATE RPC.
 func (nfs *Nfs) NFSPROC3_CREATE(args nfstypes.CREATE3args) nfstypes.CREATE3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_CREATE, time.Now())
 	var reply nfstypes.CREATE3res
@@ -454,6 +462,7 @@ func (nfs *Nfs) NFSPROC3_CREATE(args nfstypes.CREATE3args) nfstypes.CREATE3res {
 	return reply
 }
 
+// NFSPROC3_MKDIR implements the NFSv3 _MKDIR RPC.
 func (nfs *Nfs) NFSPROC3_MKDIR(args nfstypes.MKDIR3args) nfstypes.MKDIR3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_MKDIR, time.Now())
 	var reply nfstypes.MKDIR3res
@@ -474,6 +483,7 @@ func (nfs *Nfs) NFSPROC3_MKDIR(args nfstypes.MKDIR3args) nfstypes.MKDIR3res {
 	return reply
 }
 
+// NFSPROC3_SYMLINK implements the NFSv3 _SYMLINK RPC.
 func (nfs *Nfs) NFSPROC3_SYMLINK(args nfstypes.SYMLINK3args) nfstypes.SYMLINK3res {
 	var reply nfstypes.SYMLINK3res
 	util.DPrintf(1, "NFS SymLink %v\n", args)
@@ -495,6 +505,7 @@ func (nfs *Nfs) NFSPROC3_SYMLINK(args nfstypes.SYMLINK3args) nfstypes.SYMLINK3re
 	return reply
 }
 
+// NFSPROC3_READLINK implements the NFSv3 _READLINK RPC.
 func (nfs *Nfs) NFSPROC3_READLINK(args nfstypes.READLINK3args) nfstypes.READLINK3res {
 	var reply nfstypes.READLINK3res
 	util.DPrintf(1, "NFS ReadLink %v\n", args)
@@ -508,6 +519,7 @@ func (nfs *Nfs) NFSPROC3_READLINK(args nfstypes.READLINK3args) nfstypes.READLINK
 	return reply
 }
 
+// NFSPROC3_MKNOD implements the NFSv3 _MKNOD RPC.
 func (nfs *Nfs) NFSPROC3_MKNOD(args nfstypes.MKNOD3args) nfstypes.MKNOD3res {
 	var reply nfstypes.MKNOD3res
 	util.DPrintf(1, "NFS MakeNod %v\n", args)
@@ -542,6 +554,7 @@ func (nfs *Nfs) doRemove(dfh nfstypes.Nfs_fh3, name nfstypes.Filename3, isdir bo
 	return op, nfstypes.NFS3_OK
 }
 
+// NFSPROC3_REMOVE implements the NFSv3 _REMOVE RPC.
 func (nfs *Nfs) NFSPROC3_REMOVE(args nfstypes.REMOVE3args) nfstypes.REMOVE3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_REMOVE, time.Now())
 	var reply nfstypes.REMOVE3res
@@ -555,6 +568,7 @@ func (nfs *Nfs) NFSPROC3_REMOVE(args nfstypes.REMOVE3args) nfstypes.REMOVE3res {
 	return reply
 }
 
+// NFSPROC3_RMDIR implements the NFSv3 _RMDIR RPC.
 func (nfs *Nfs) NFSPROC3_RMDIR(args nfstypes.RMDIR3args) nfstypes.RMDIR3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_RMDIR, time.Now())
 	var reply nfstypes.RMDIR3res
@@ -599,6 +613,7 @@ func validateRename(op *fstxn.FsTxn, inodes []*inode.Inode, fromfh fh.Fh, tofh f
 	return true
 }
 
+// NFSPROC3_RENAME implements the NFSv3 _RENAME RPC.
 func (nfs *Nfs) NFSPROC3_RENAME(args nfstypes.RENAME3args) nfstypes.RENAME3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_RENAME, time.Now())
 	var reply nfstypes.RENAME3res
@@ -742,6 +757,7 @@ func (nfs *Nfs) NFSPROC3_RENAME(args nfstypes.RENAME3args) nfstypes.RENAME3res {
 	return reply
 }
 
+// NFSPROC3_LINK implements the NFSv3 _LINK RPC.
 func (nfs *Nfs) NFSPROC3_LINK(args nfstypes.LINK3args) nfstypes.LINK3res {
 	var reply nfstypes.LINK3res
 	util.DPrintf(1, "NFS Link %v\n", args)
@@ -751,6 +767,7 @@ func (nfs *Nfs) NFSPROC3_LINK(args nfstypes.LINK3args) nfstypes.LINK3res {
 	return reply
 }
 
+// NFSPROC3_READDIR implements the NFSv3 _READDIR RPC.
 func (nfs *Nfs) NFSPROC3_READDIR(args nfstypes.READDIR3args) nfstypes.READDIR3res {
 	var reply nfstypes.READDIR3res
 	util.DPrintf(1, "NFS ReadDir %v\n", args)
@@ -770,6 +787,7 @@ func (nfs *Nfs) NFSPROC3_READDIR(args nfstypes.READDIR3args) nfstypes.READDIR3re
 	return reply
 }
 
+// NFSPROC3_READDIRPLUS implements the NFSv3 _READDIRPLUS RPC.
 func (nfs *Nfs) NFSPROC3_READDIRPLUS(args nfstypes.READDIRPLUS3args) nfstypes.READDIRPLUS3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_READDIRPLUS, time.Now())
 	var reply nfstypes.READDIRPLUS3res
@@ -790,6 +808,7 @@ func (nfs *Nfs) NFSPROC3_READDIRPLUS(args nfstypes.READDIRPLUS3args) nfstypes.RE
 	return reply
 }
 
+// NFSPROC3_FSSTAT implements the NFSv3 _FSSTAT RPC.
 func (nfs *Nfs) NFSPROC3_FSSTAT(args nfstypes.FSSTAT3args) nfstypes.FSSTAT3res {
 	var reply nfstypes.FSSTAT3res
 	util.DPrintf(1, "NFS FsStat %v\n", args)
@@ -797,6 +816,7 @@ func (nfs *Nfs) NFSPROC3_FSSTAT(args nfstypes.FSSTAT3args) nfstypes.FSSTAT3res {
 	return reply
 }
 
+// NFSPROC3_FSINFO implements the NFSv3 _FSINFO RPC.
 func (nfs *Nfs) NFSPROC3_FSINFO(args nfstypes.FSINFO3args) nfstypes.FSINFO3res {
 	var reply nfstypes.FSINFO3res
 	util.DPrintf(1, "NFS FsInfo %v\n", args)
@@ -814,6 +834,7 @@ func (nfs *Nfs) NFSPROC3_FSINFO(args nfstypes.FSINFO3args) nfstypes.FSINFO3res {
 	return reply
 }
 
+// NFSPROC3_PATHCONF implements the NFSv3 _PATHCONF RPC.
 func (nfs *Nfs) NFSPROC3_PATHCONF(args nfstypes.PATHCONF3args) nfstypes.PATHCONF3res {
 	var reply nfstypes.PATHCONF3res
 	util.DPrintf(1, "NFS PathConf %v\n", args)
@@ -828,6 +849,7 @@ func (nfs *Nfs) NFSPROC3_PATHCONF(args nfstypes.PATHCONF3args) nfstypes.PATHCONF
 // RFC: forces or flushes data to stable storage that was previously
 // written with a WRITE procedure call with the stable field set to
 // UNSTABLE.
+// NFSPROC3_COMMIT implements the NFSv3 _COMMIT RPC.
 func (nfs *Nfs) NFSPROC3_COMMIT(args nfstypes.COMMIT3args) nfstypes.COMMIT3res {
 	defer nfs.recordOp(nfstypes.NFSPROC3_COMMIT, time.Now())
 	var reply nfstypes.COMMIT3res

--- a/super/super.go
+++ b/super/super.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mit-pdos/go-journal/common"
 )
 
+// FsSuper holds computed values describing the on-disk layout.
 type FsSuper struct {
 	Disk         disk.Disk
 	Size         uint64
@@ -17,6 +18,7 @@ type FsSuper struct {
 	Maxaddr      uint64
 }
 
+// MkFsSuper builds a super block description for disk d.
 func MkFsSuper(d disk.Disk) *FsSuper {
 	sz := d.Size()
 	nblockbitmap := (sz / common.NBITBLOCK) + 1
@@ -31,34 +33,42 @@ func MkFsSuper(d disk.Disk) *FsSuper {
 		Maxaddr:      sz}
 }
 
+// MaxBnum returns the maximum block number in the file system.
 func (fs *FsSuper) MaxBnum() common.Bnum {
 	return common.Bnum(fs.Maxaddr)
 }
 
+// BitmapBlockStart returns the block number of the first block bitmap block.
 func (fs *FsSuper) BitmapBlockStart() common.Bnum {
 	return common.Bnum(fs.nLog)
 }
 
+// BitmapInodeStart returns the block number of the first inode bitmap block.
 func (fs *FsSuper) BitmapInodeStart() common.Bnum {
 	return fs.BitmapBlockStart() + common.Bnum(fs.NBlockBitmap)
 }
 
+// InodeStart returns the first block containing inodes.
 func (fs *FsSuper) InodeStart() common.Bnum {
 	return fs.BitmapInodeStart() + common.Bnum(fs.NInodeBitmap)
 }
 
+// DataStart returns the first data block after metadata.
 func (fs *FsSuper) DataStart() common.Bnum {
 	return fs.InodeStart() + common.Bnum(fs.nInodeBlk)
 }
 
+// Block2addr converts a block number to a disk address.
 func (fs *FsSuper) Block2addr(blkno common.Bnum) addr.Addr {
 	return addr.MkAddr(blkno, 0)
 }
 
+// NInode returns the number of inodes in the file system.
 func (fs *FsSuper) NInode() common.Inum {
 	return common.Inum(fs.nInodeBlk * common.INODEBLK)
 }
 
+// Inum2Addr computes the disk address of the given inode number.
 func (fs *FsSuper) Inum2Addr(inum common.Inum) addr.Addr {
 	return addr.MkAddr(fs.InodeStart()+common.Bnum(uint64(inum)/common.INODEBLK),
 		(uint64(inum)%common.INODEBLK)*common.INODESZ*8)


### PR DESCRIPTION
## Summary
- add GoDoc comments for exported identifiers in nfs, super, alloctxn, shrinker, kvs and inode packages
- document NFS RPC handlers

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*